### PR TITLE
Fix crash when no results from Open Cage

### DIFF
--- a/lib/open_cagex/parser.ex
+++ b/lib/open_cagex/parser.ex
@@ -11,7 +11,7 @@ defmodule OpenCagex.Parser do
     value = results
     |> parse_results
     |> first_result
-    |> Map.get(key)
+    |> get_key(key)
 
     {:ok, value}
   end
@@ -19,4 +19,7 @@ defmodule OpenCagex.Parser do
   defp parse_results(%{"results" => results}), do: results
 
   defp first_result(results), do: Enum.at(results, 0)
+
+  defp get_key(nil, key), do: nil
+  defp get_key(results, key), do: Map.get(results, key)
 end

--- a/mix.exs
+++ b/mix.exs
@@ -43,6 +43,7 @@ defmodule OpenCagex.Mixfile do
       {:poison, "~> 3.1"},
       {:credo, "~> 0.3", only: [:dev, :test]},
       {:ex_doc, "~> 0.14", only: :dev, runtime: false},
+      {:mock, "~> 0.3.1", only: :test},
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
-%{"bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
+%{
+  "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
   "certifi": {:hex, :certifi, "1.2.1", "c3904f192bd5284e5b13f20db3ceac9626e14eeacfbb492e19583cf0e37b22be", [:rebar3], [], "hexpm"},
   "credo": {:hex, :credo, "0.8.1", "137efcc99b4bc507c958ba9b5dff70149e971250813cbe7d4537ec7e36997402", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.2", "f718159d6b65068e8daeef709ccddae5f7fdc770707d82e7d126f584cd925b74", [:mix], [], "hexpm"},
@@ -6,8 +7,11 @@
   "hackney": {:hex, :hackney, "1.8.6", "21a725db3569b3fb11a6af17d5c5f654052ce9624219f1317e8639183de4a423", [:rebar3], [{:certifi, "1.2.1", [hex: :certifi, repo: "hexpm", optional: false]}, {:idna, "5.0.2", [hex: :idna, repo: "hexpm", optional: false]}, {:metrics, "1.0.1", [hex: :metrics, repo: "hexpm", optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, repo: "hexpm", optional: false]}, {:ssl_verify_fun, "1.1.1", [hex: :ssl_verify_fun, repo: "hexpm", optional: false]}], "hexpm"},
   "httpoison": {:hex, :httpoison, "0.11.2", "9e59f17a473ef6948f63c51db07320477bad8ba88cf1df60a3eee01150306665", [:mix], [{:hackney, "~> 1.8.0", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},
   "idna": {:hex, :idna, "5.0.2", "ac203208ada855d95dc591a764b6e87259cb0e2a364218f215ad662daa8cd6b4", [:rebar3], [{:unicode_util_compat, "0.2.0", [hex: :unicode_util_compat, repo: "hexpm", optional: false]}], "hexpm"},
+  "meck": {:hex, :meck, "0.8.9", "64c5c0bd8bcca3a180b44196265c8ed7594e16bcc845d0698ec6b4e577f48188", [], [], "hexpm"},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], [], "hexpm"},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], [], "hexpm"},
+  "mock": {:hex, :mock, "0.3.1", "994f00150f79a0ea50dc9d86134cd9ebd0d177ad60bd04d1e46336cdfdb98ff9", [], [{:meck, "~> 0.8.8", [hex: :meck, repo: "hexpm", optional: false]}], "hexpm"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], [], "hexpm"},
-  "unicode_util_compat": {:hex, :unicode_util_compat, "0.2.0", "dbbccf6781821b1c0701845eaf966c9b6d83d7c3bfc65ca2b78b88b8678bfa35", [:rebar3], [], "hexpm"}}
+  "unicode_util_compat": {:hex, :unicode_util_compat, "0.2.0", "dbbccf6781821b1c0701845eaf966c9b6d83d7c3bfc65ca2b78b88b8678bfa35", [:rebar3], [], "hexpm"},
+}

--- a/test/open_cagex/parser_test.exs
+++ b/test/open_cagex/parser_test.exs
@@ -1,0 +1,32 @@
+defmodule OpenCagex.ParserTest do
+  use ExUnit.Case
+  doctest OpenCagex.Parser
+
+  describe "formatted_address/1" do
+    test "returns value when results are present" do
+      input = %{"results" => [%{"formatted" => true}]}
+
+      assert {:ok, true} = OpenCagex.Parser.formatted_address(input)
+    end
+
+    test "returns when there are no results" do
+      input = %{"results" => []}
+
+      assert {:ok, nil} = OpenCagex.Parser.formatted_address(input)
+    end
+  end
+
+  describe "geocode/1" do
+    test "returns value when results are present" do
+      input = %{"results" => [%{"geometry" => true}]}
+
+      assert {:ok, true} = OpenCagex.Parser.geocode(input)
+    end
+
+    test "returns when there are no results" do
+      input = %{"results" => []}
+
+      assert {:ok, nil} = OpenCagex.Parser.geocode(input)
+    end
+  end
+end

--- a/test/opencagex_test.exs
+++ b/test/opencagex_test.exs
@@ -19,7 +19,7 @@ defmodule OpenCagexTest do
 
   describe "when given a place name" do
     test "returns a geocode" do
-      expected_result = {:ok, %{"lat" => 41.3778504, "lng" => 2.1778608}}
+      expected_result = {:ok, %{"lat" => 41.377655, "lng" => 2.1780917}}
       assert expected_result == OpenCagex.geocode("Passatge de la Pau, Barcelona")
     end
   end

--- a/test/opencagex_test.exs
+++ b/test/opencagex_test.exs
@@ -2,25 +2,45 @@ defmodule OpenCagexTest do
   use ExUnit.Case
   doctest OpenCagex
 
-  @api_key System.get_env("OPEN_CAGE_API_KEY")
+  import Mock
 
-  setup_all do
-    assert(@api_key != nil)
-
-    OpenCagex.set_api_key(@api_key)
+  defmacro with_request_mock(result, block) do
+    quote do
+      with_mock HTTPoison,
+        get: fn _url ->
+          {
+            :ok,
+            %{
+              body: Poison.encode!(%{results: [unquote(result)]}),
+              status_code: 200,
+              headers: []
+            }
+          }
+        end do
+        unquote(block)
+      end
+    end
   end
 
   describe "when given a latitude and longitude" do
     test "reverses the coordinates and returns a formated address" do
-      expected_result = {:ok, "Moog, Carrer de l'Arc del Teatre, 3, 08001 Barcelona, Spain"}
-      assert expected_result == OpenCagex.reverse(41.3780845, 2.1751182)
+      result = "Moog, Carrer de l'Arc del Teatre, 3, 08001 Barcelona, Spain"
+
+      with_request_mock %{formatted: result} do
+        expected_result = {:ok, result}
+        assert expected_result == OpenCagex.reverse(41.3780845, 2.1751182)
+      end
     end
   end
 
   describe "when given a place name" do
     test "returns a geocode" do
-      expected_result = {:ok, %{"lat" => 41.377655, "lng" => 2.1780917}}
-      assert expected_result == OpenCagex.geocode("Passatge de la Pau, Barcelona")
+      result = %{"lat" => 41.377655, "lng" => 2.1780917}
+
+      with_request_mock %{geometry: result} do
+        expected_result = {:ok, result}
+        assert expected_result == OpenCagex.geocode("Passatge de la Pau, Barcelona")
+      end
     end
   end
 end


### PR DESCRIPTION
When calling Open Cage, sometimes there's no results (`results` key is empty array). This was causing the following issue:

```
** (BadMapError) expected a map, got: nil
     code: assert {:ok, nil} = OpenCagex.Parser.geocode(input)
     stacktrace:
       (elixir) lib/map.ex:421: Map.get(nil, "geometry", nil)
       (open_cagex) lib/open_cagex/parser.ex:14: OpenCagex.Parser.get_by_key/2
       test/open_cagex/parser_test.exs:29: (test)
```

This PR fixes it 🎉 